### PR TITLE
returning

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -161,10 +161,10 @@ Cursor <- setRefClass("Cursor",
         to_iso_8601(start),
         to_iso_8601(end)
       )
-      url <- sprintf("%s/query/%s/events", client$host, cursor)
       events <- list()
 
       while(!is.null(cursor)) {
+        url <- sprintf("%s/query/%s/events", client$host, cursor)
         r <- GET(url, client$get_api_headers())
         code <- status_code(r)
 

--- a/R/flare.R
+++ b/R/flare.R
@@ -427,14 +427,14 @@ StreamProjection <- setRefClass('StreamProjection',
         p <- if (isTRUE(proj)) 'default' else FALSE
         list(stream = stream$to_ast(), projection = p)
       } else {
-        go <- function (proj) {
+        proj_ast <- function (proj) {
           Reduce(
             function(out, name) {
               ast <- switch(
                 class(proj[[name]]),
                   ProjMath = list(proj[[name]]$to_ast()),
                   EventPath = list(list(var = proj[[name]]$to_ast()$path)),
-                  list = go(proj[[name]]),
+                  list = proj_ast(proj[[name]]),
                   numeric = list(list(lit = list(val = proj[[name]], type = 'double'))),
                   logical = list(list(lit = list(val = proj[[name]], type = 'bool'))),
                   character = list(list(lit = list(val = proj[[name]], type = 'string'))),
@@ -448,7 +448,7 @@ StreamProjection <- setRefClass('StreamProjection',
           )
         }
 
-        list(stream = stream$to_ast(), projection = go(proj))
+        list(stream = stream$to_ast(), projection = proj_ast(proj))
       }
     }
   )

--- a/tests/testthat/test-flare.R
+++ b/tests/testthat/test-flare.R
@@ -207,6 +207,34 @@ test_that('or stream filters', {
   expect_equal(real, expected)
 })
 
+test_that('returning', {
+  s <- stream('weather')
+  real <- select()$span(returning = from(s, list(value = V.maxTemp, other = list(constant = 3))))$to_ast()
+  print(rjson::toJSON(real))
+  expected <- list(
+    select = list(expr = TRUE),
+    projections = list(
+      explicit = list(
+        list(
+          stream = list(name = 'weather'),
+          projection = list(
+            value = list(
+              list(var = c('event', 'maxTemp'))
+            ),
+            other = list(
+              constant = list(
+                list(lit = list(val = 3, type = 'double'))
+              )
+            )
+          )
+        )
+      ),
+      ... = TRUE
+    )
+  )
+  expect_equal(real, expected)
+})
+
 test_that('switches', {
   s <- stream('S')
   real <- select()$span(s:(V.x < 0 -> V.x > 0))$to_ast()

--- a/tests/testthat/test-flare.R
+++ b/tests/testthat/test-flare.R
@@ -281,6 +281,57 @@ test_that('realistic returning', {
   expect_equal(real, expected)
 })
 
+test_that('returning op', {
+  weather <- stream('weather')
+  real <- select()$span(
+    returning = from(weather, list(
+      air = 5 / 9 * (V.air_temp - 32),
+      air_unit = 'C'
+    ))
+  )$to_ast()
+
+  expected <- list(
+    select = list(expr = TRUE),
+    projections = list(
+      explicit = list(
+        list(
+          stream = list(name = 'weather'),
+          projection = list(
+            air = list(
+              list(
+                op = '*',
+                lhs = list(
+                  op = '/',
+                  lhs = list(
+                    lit = list(val = 5, type = 'double')
+                  ),
+                  rhs = list(
+                    lit = list(val = 9, type = 'double')
+                  )
+                ),
+                rhs = list(
+                  op = '-',
+                  lhs = list(
+                    var = c('event', 'air_temp')
+                  ),
+                  rhs = list(
+                    lit = list(val = 32, type = 'double')
+                  )
+                )
+              )
+            ),
+            air_unit = list(
+              list(lit = list(val = 'C', type = 'string'))
+            )
+          )
+        )
+      ),
+      ... = TRUE
+    )
+  )
+  expect_equal(real, expected)
+})
+
 test_that('switches', {
   s <- stream('S')
   real <- select()$span(s:(V.x < 0 -> V.x > 0))$to_ast()

--- a/tests/testthat/test-flare.R
+++ b/tests/testthat/test-flare.R
@@ -210,7 +210,6 @@ test_that('or stream filters', {
 test_that('returning', {
   s <- stream('weather')
   real <- select()$span(returning = from(s, list(value = V.maxTemp, other = list(constant = 3))))$to_ast()
-  print(rjson::toJSON(real))
   expected <- list(
     select = list(expr = TRUE),
     projections = list(
@@ -225,6 +224,53 @@ test_that('returning', {
               constant = list(
                 list(lit = list(val = 3, type = 'double'))
               )
+            )
+          )
+        )
+      ),
+      ... = TRUE
+    )
+  )
+  expect_equal(real, expected)
+})
+
+test_that('realistic returning', {
+  weather <- stream('weather')
+  real <- select()$span(
+    returning = from(weather, list(
+      air = V.air_temp,
+      air_unit = 'F',
+      hum = V.humidity,
+      hum_unit = '%',
+      co2 = V.co2,
+      co2_unit = 'ppm'
+    ))
+  )$to_ast()
+
+  expected <- list(
+    select = list(expr = TRUE),
+    projections = list(
+      explicit = list(
+        list(
+          stream = list(name = 'weather'),
+          projection = list(
+            air = list(
+              list(var = c('event', 'air_temp'))
+            ),
+            air_unit = list(
+              list(lit = list(val = 'F', type = 'string'))
+            ),
+            hum = list(
+              list(var = c('event', 'humidity'))
+            ),
+            hum_unit = list(
+              list(lit = list(val = '%', type = 'string'))
+            ),
+            co2 = list(
+              list(var = c('event', 'co2'))
+            ),
+            co2_unit = list(
+              list(lit = list(val = 'ppm', type = 'string'))
             )
           )
         )


### PR DESCRIPTION
fixes #6 

found a bug on the back end with projection math. it sounds like a quick fix, so i'm gonna wait on that before testing math and merging this.

@xnomagichash we currently call `from` to bind a projection to a stream (take a look at the tests). `%` didn't seem to parse well, but R lets you define arbitrary infix operators that are wrapped in `%` like `%op%`. `%%` is also an option.